### PR TITLE
Kubernetes volumes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: bash
 sudo: required
 

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secret.yaml
+++ b/kubernetes-volumes/minio-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+data:
+  access_key: bWluaW8=
+  secret_key: bWluaW8xMjM=

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above.
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -18,13 +18,19 @@ spec:
       - name: minio
         env:
         - name: MINIO_ACCESS_KEY
-          value: "minio"
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: access_key
         - name: MINIO_SECRET_KEY
-          value: "minio123"
+          valueFrom:
+            secretKeyRef:
+              name: minio
+              key: secret_key
         image: minio/minio:RELEASE.2019-07-10T00-34-56Z
         args:
         - server
-        - /data 
+        - /data
         ports:
         - containerPort: 9000
         # These volume mounts are persistent. Each pod in the PetSet


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Установка kind

  ```bash
  $ cd /tmp && curl -Lo ./kind-darwin-amd64 https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-darwin-amd64
  $ chmod +x ./kind-darwin-amd64 && sudo mv ./kind-darwin-amd64 /usr/local/bin/kind
  ```

- Запуск kind

  ```bash
  $ kind create cluster
  $ export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
  ```

### StatefulSet

- Применим манифест для StatefulSet

  ```bash
  $ curl -Lo ./minio-statefulset.yaml https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-statefulset.yaml
  $ kubectl -f minio-statefulset.yaml
  ```

  <details><summary>Подробнее</summary><p>
  
  ```bash
  $ kubectl get pods
    NAME      READY   STATUS    RESTARTS   AGE
    minio-0   1/1     Running   0          17m
  ```

  ```bash
  $ kubectl get statefulsets
    NAME    READY   AGE
    minio   1/1     20m
  ```

  ```bash
  $ kubectl get pv
    NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
    pvc-5d582e73-50ff-4910-9d71-a0d9fb877f36   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                20m
  ```

  ```bash
  $ kubectl get pvc
    NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
    data-minio-0   Bound    pvc-5d582e73-50ff-4910-9d71-a0d9fb877f36   10Gi       RWO            standard       20m
  ```
  </p>
  </details>

### Headless Service

- Применим манифест для Headless Service

  ```bash
  $ curl -Lo ./minio-headless-service.yaml https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Kuberenetes-volumes/minio-headless-service.yaml
  $ kubectl -f minio-headless-service.yaml
  ```

  <details><summary>Подробнее</summary><p>
  
  ```bash
  $ kubectl get service
    NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
    kubernetes   ClusterIP   10.96.0.1    <none>        443/TCP    36m
    minio        ClusterIP   None         <none>        9000/TCP   27m
  ```
  </p>
  </details>

### Secrets

- Создание Secret

  ```bash
  apiVersion: v1
  kind: Secret
  metadata:
    name: minio
  data:
    access_key: bWluaW8=
    secret_key: bWluaW8xMjM=
  ```
- Применение манифеста с секретом

  ```bash
  $ kubectl apply -f kubernetes-volumes/minio-secret.yaml
    secret/minio created
  ```

  <details><summary>Подробнее</summary><p>
  
  ```bash
  $ kubectl get secrets
    NAME                  TYPE                                  DATA   AGE
    default-token-f8dkg   kubernetes.io/service-account-token   3      38m
    minio                 Opaque                                2      6s
  ```
  </p>
  </details>

- Обновляем StatefulSet для использования внось созданного секрета

  ```bash
  ...

      spec:
      containers:
      - name: minio
        env:
        - name: MINIO_ACCESS_KEY
          valueFrom:
            secretKeyRef:
              name: minio
              key: access_key
        - name: MINIO_SECRET_KEY
          valueFrom:
            secretKeyRef:
              name: minio
              key: secret_key
        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
  
  ...
  ```

## Как запустить проект:
 - kubectl apply -f kubernetes-volumes/

## Как проверить работоспособность:
 - kubectl get statefulsets
 - kubectl get pods
 - kubectl get pv
 - kubectl get pvc
 - kubectl get service
 - kubectl get secret

## PR checklist:
 - [x] Выставлен label с номером домашнего задания
